### PR TITLE
fix: 修复 MCP 工具注册与调用协议兼容问题

### DIFF
--- a/aj-mcp-server/src/main/java/com/ajaxjs/mcp/server/McpServer.java
+++ b/aj-mcp-server/src/main/java/com/ajaxjs/mcp/server/McpServer.java
@@ -154,18 +154,21 @@ public class McpServer extends McpServerPrompt {
         Object[] argValues = null;
 
         if (inputSchema != null) {
-            if (arguments == null || arguments.isEmpty())
-                throw new JsonRpcErrorException(requestRaw.getId(), JsonRpcErrorCode.INVALID_PARAMS, "arguments is required!");
-
             List<String> required = inputSchema.getRequired();
-            if (arguments.size() < required.size())
-                throw new JsonRpcErrorException(requestRaw.getId(), JsonRpcErrorCode.INVALID_PARAMS, "arguments size is not match!");
-
             Map<String, JsonSchemaProperty> argumentsDefined = inputSchema.getProperties();
             List<String> paramsOrder = store.getParamsOrder();
-            argValues = new Object[paramsOrder.size()];
 
+            // 无参工具（未定义任何参数）允许省略 arguments，直接以无参方式调用；
+            // 只有定义过参数的工具才要求客户端提供 arguments
             if (argumentsDefined != null && !argumentsDefined.isEmpty()) {
+                if (arguments == null || arguments.isEmpty())
+                    throw new JsonRpcErrorException(requestRaw.getId(), JsonRpcErrorCode.INVALID_PARAMS, "arguments is required!");
+
+                if (arguments.size() < required.size())
+                    throw new JsonRpcErrorException(requestRaw.getId(), JsonRpcErrorCode.INVALID_PARAMS, "arguments size is not match!");
+
+                argValues = new Object[paramsOrder.size()];
+
                 for (int i = 0; i < paramsOrder.size(); i++) {
                     String name = paramsOrder.get(i);
                     Object arg = arguments.get(name);
@@ -253,6 +256,7 @@ public class McpServer extends McpServerPrompt {
             case "string":
                 return value.toString();
             case "number":
+            case "integer":
                 // 首先检查是否是数字类型
                 if (value instanceof Number) {
                     Number numberValue = (Number) value;
@@ -296,6 +300,10 @@ public class McpServer extends McpServerPrompt {
                     return Boolean.parseBoolean(strValue);
 
                 throw new IllegalArgumentException("Value cannot be converted to Boolean: " + value);
+
+            case "object":
+                // JSON 对象类型参数直接原样返回
+                return value;
 
             default:
                 throw new IllegalArgumentException("Unsupported targetType: " + targetType);

--- a/aj-mcp-server/src/main/java/com/ajaxjs/mcp/server/feature/FeatureMgr.java
+++ b/aj-mcp-server/src/main/java/com/ajaxjs/mcp/server/feature/FeatureMgr.java
@@ -18,6 +18,13 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -107,7 +114,6 @@ public class FeatureMgr {
 
         Map<String, JsonSchemaProperty> properties = new HashMap<>();
         List<String> required = new ArrayList<>();
-        boolean hasArgs = false;
         Parameter[] parameters = method.getParameters();
         List<String> paramsOrder = null;
 
@@ -115,7 +121,6 @@ public class FeatureMgr {
             paramsOrder = new ArrayList<>();
             for (Parameter parameter : parameters) {
                 if (parameter.isAnnotationPresent(ToolArg.class)) {
-                    hasArgs = true;
                     ToolArg arg = parameter.getAnnotation(ToolArg.class);
                     String name = arg.value().isEmpty() ? parameter.getName() : arg.value();
                     JsonSchemaProperty property = new JsonSchemaProperty();
@@ -130,18 +135,17 @@ public class FeatureMgr {
                 }
             }
         }
+        // 无论是否有参数，都生成合法的 JSON Schema（无参工具为空的 {"type":"object","properties":{}}），
+        // 否则 MCP 规范要求 inputSchema 必须是对象，严格客户端会校验失败
         JsonSchema inputSchema = new JsonSchema();
-
-        if (hasArgs) {
-            inputSchema.setType("object");
-            inputSchema.setProperties(properties);
-            inputSchema.setRequired(required);
-        }
+        inputSchema.setType("object");
+        inputSchema.setProperties(properties);
+        inputSchema.setRequired(required);
 
         ToolItem toolItem = new ToolItem();
         toolItem.setName(toolName);
         toolItem.setDescription(description);
-        toolItem.setInputSchema(hasArgs ? inputSchema : null);
+        toolItem.setInputSchema(inputSchema);
 
         ServerStoreTool store = new ServerStoreTool();
         store.setMethod(method);
@@ -164,26 +168,31 @@ public class FeatureMgr {
         // 获取参数的类型
         Class<?> type = parameter.getType();
 
-        // 基础类型和包装类型的映射
+        // 基础类型和包装类型的映射（JSON Schema 的 type 必须是小写）
         if (type.isPrimitive()) {
-            if (type == byte.class || type == short.class || type == int.class ||
-                    type == long.class || type == float.class || type == double.class)
+            if (type == byte.class || type == short.class || type == int.class || type == long.class)
+                return "integer";
+            else if (type == float.class || type == double.class)
                 return "number";
             else if (type == boolean.class)
                 return "boolean";
             else if (type == char.class)
                 return "string";
         } else {
-            if (Number.class.isAssignableFrom(type))
-                return "Number";
-            else if (type == Boolean.class)
-                return "Boolean";
+            if (type == Boolean.class)
+                return "boolean";
             else if (type == Character.class || type == String.class)
                 return "string";
+            else if (Number.class.isAssignableFrom(type)) {
+                // 浮点类型映射为 number，其余数字类型映射为 integer
+                if (type == Float.class || type == Double.class || type == BigDecimal.class)
+                    return "number";
+                return "integer";
+            }
         }
 
-        // 其他类型默认返回 Object
-        return "Object";
+        // 其他类型默认返回 object
+        return "object";
     }
 
     /**


### PR DESCRIPTION
1. 无参工具生成合法的空 inputSchema（{"type":"object","properties":{}}）， 避免严格客户端校验 tools/list 时报 inputSchema 为 null
2. toolCall 允许无参工具省略 arguments，直接以无参方式调用
3. mapJavaTypeToJsType 输出 JSON Schema 合法小写类型 （integer/number/boolean/string/object），修复大写 Number/Boolean/Object 非法值
4. convertToType 支持 integer/object 类型转换

Fixes #1234